### PR TITLE
fix: codecov comment behavior to default

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,7 +10,7 @@ coverage:
 
 comment:
   layout: "reach, diff, flags, files"
-  behavior: update
+  behavior: default
   require_changes: false
 
 ignore:


### PR DESCRIPTION
`codecov.yaml` is invalid. `comment.behavior`

```shell
> curl --data-binary @codecov.yaml https://codecov.io/validate 

Error at ['comment', 'behavior']: 
unallowed value update
```

fixed this by changing it to `default`.