### PR TITLE
Add Discord Solve/First Blood Notifications, Nickname Synchronization, and 10-Character Name Limit

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,7 +118,7 @@ func main() {
 			RedirectURI:  cfg.Discord.RedirectURI,
 			Scopes:       cfg.Discord.Scopes,
 		}, cfg.Discord.OAuthTimeout)
-		discordSvc = service.NewDiscordService(cfg.Discord, discordRepo, discordBotClient, discordOAuthClient, redisClient)
+		discordSvc = service.NewDiscordService(cfg.Discord, discordRepo, userRepo, discordBotClient, discordOAuthClient, redisClient)
 	}
 
 	bootstrap.BootstrapAdmin(ctx, cfg, database, userRepo, teamRepo, divisionRepo, logger)

--- a/docs/docs/admin.md
+++ b/docs/docs/admin.md
@@ -303,6 +303,10 @@ Errors:
 - 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
 
+Validation notes:
+
+- `name` must be at most 10 characters (counted by Unicode code point).
+
 ---
 
 ## Create Division (Admin)
@@ -332,6 +336,10 @@ Errors:
 - 400 `invalid input`
 - 401 `invalid token` or `missing access_token cookie`
 - 403 `forbidden`
+
+Validation notes:
+
+- `name` must be at most 10 characters (counted by Unicode code point).
 
 ---
 

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -35,6 +35,7 @@ Errors:
 
 Validation notes:
 
+- `username` must be at most 10 characters (counted by Unicode code points).
 - `password` must be at most 72 bytes (bcrypt input limit).
 
 `registration_key` must be an admin-created alphanumeric code.

--- a/docs/docs/discord.md
+++ b/docs/docs/discord.md
@@ -12,6 +12,25 @@ Notes:
 - For authenticated `POST`, `PUT`, `PATCH`, and `DELETE` requests, send both `csrf_token` cookie and matching `X-CSRF-Token` header.
 - All endpoints return `503 discord feature disabled` when `DISCORD_ENABLED=false`.
 
+## Solve Announcements & Nickname Sync
+
+When `DISCORD_ENABLED=true`, the backend performs two best-effort side effects
+through the invite-bot (failures are logged, never surfaced to the user):
+
+- **Solve announcements** — on a correct flag submission, a message is sent to the
+  channel `DISCORD_ANNOUNCE_CHANNEL_ID` (no-op when unset):
+    - Normal solve: `**division_team** — username solved **Challenge Title**`
+    - First blood: prefixed with 🩸 `First Blood!`
+
+    Announcements are independent of whether the solving user has linked their own
+    Discord account.
+
+- **Guild nickname sync** — when a user links Discord or changes their username,
+  the linked guild member's nickname is set to `division_team_username`. Because
+  `username`, team `name`, and division `name` are each capped at 10 characters,
+  this always fits Discord's 32-character nickname limit
+  (10 + 10 + 10 + two underscores).
+
 ## Discord Status Schema
 
 `discordStatusResponse` fields (omitted when empty):
@@ -210,6 +229,7 @@ Discord service options (backend):
 - `DISCORD_BOT_BASE_URL` (default: `http://localhost:8083`)
 - `DISCORD_BOT_SECRET` — shared bearer secret for the invite-bot internal API (must equal the bot's `DISCORD_INTERNAL_SECRET`).
 - `DISCORD_BOT_TIMEOUT` (default: `5s`)
+- `DISCORD_ANNOUNCE_CHANNEL_ID` — target channel for solve / first-blood announcements. Empty disables announcements (configured on the invite-bot server).
 
 Validation rules when `DISCORD_ENABLED=true`:
 

--- a/docs/docs/users.md
+++ b/docs/docs/users.md
@@ -92,6 +92,7 @@ Errors:
 
 Notes:
 
+- `username` must be at most 10 characters (counted by Unicode code point).
 - `vm_count` and `vm_limit` reflect the configured scope. If `VMS_MAX_SCOPE=team`, these values are team-wide.
 
 ---

--- a/internal/discord/client.go
+++ b/internal/discord/client.go
@@ -71,6 +71,8 @@ type BotAPI interface {
 	GrantRole(ctx context.Context, discordUserID string) error
 	KickMember(ctx context.Context, discordUserID string) error
 	GetMember(ctx context.Context, discordUserID string) (*Member, error)
+	Announce(ctx context.Context, content string) error
+	SetNickname(ctx context.Context, discordUserID, nickname string) error
 }
 
 type BotClient struct {
@@ -93,6 +95,14 @@ type joinRequest struct {
 	AccessToken string `json:"access_token"`
 }
 
+type announceRequest struct {
+	Content string `json:"content"`
+}
+
+type nicknameRequest struct {
+	Nickname string `json:"nickname"`
+}
+
 func (c *BotClient) JoinGuild(ctx context.Context, discordUserID, accessToken string) error {
 	return c.doJSON(ctx, http.MethodPut, "/internal/guild/members/"+url.PathEscape(discordUserID), joinRequest{AccessToken: accessToken}, nil)
 }
@@ -103,6 +113,14 @@ func (c *BotClient) GrantRole(ctx context.Context, discordUserID string) error {
 
 func (c *BotClient) KickMember(ctx context.Context, discordUserID string) error {
 	return c.doJSON(ctx, http.MethodDelete, "/internal/guild/members/"+url.PathEscape(discordUserID), nil, nil)
+}
+
+func (c *BotClient) Announce(ctx context.Context, content string) error {
+	return c.doJSON(ctx, http.MethodPost, "/internal/announce", announceRequest{Content: content}, nil)
+}
+
+func (c *BotClient) SetNickname(ctx context.Context, discordUserID, nickname string) error {
+	return c.doJSON(ctx, http.MethodPatch, "/internal/guild/members/"+url.PathEscape(discordUserID)+"/nickname", nicknameRequest{Nickname: nickname}, nil)
 }
 
 func (c *BotClient) GetMember(ctx context.Context, discordUserID string) (*Member, error) {

--- a/internal/discord/client_test.go
+++ b/internal/discord/client_test.go
@@ -137,3 +137,53 @@ func TestBotClientUnavailableOnDialError(t *testing.T) {
 		t.Fatalf("got %v, want ErrUnavailable", err)
 	}
 }
+
+func TestBotClientAnnounce(t *testing.T) {
+	var gotMethod, gotPath string
+	var body announceRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewBotClient(srv.URL, "secret", time.Second)
+	if err := client.Announce(context.Background(), "hello world"); err != nil {
+		t.Fatalf("Announce: %v", err)
+	}
+
+	if gotMethod != http.MethodPost || gotPath != "/internal/announce" {
+		t.Errorf("method=%q path=%q", gotMethod, gotPath)
+	}
+
+	if body.Content != "hello world" {
+		t.Errorf("content = %q", body.Content)
+	}
+}
+
+func TestBotClientSetNickname(t *testing.T) {
+	var gotMethod, gotPath string
+	var body nicknameRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewBotClient(srv.URL, "secret", time.Second)
+	if err := client.SetNickname(context.Background(), "123", "Div_Team_neo"); err != nil {
+		t.Fatalf("SetNickname: %v", err)
+	}
+
+	if gotMethod != http.MethodPatch || gotPath != "/internal/guild/members/123/nickname" {
+		t.Errorf("method=%q path=%q", gotMethod, gotPath)
+	}
+
+	if body.Nickname != "Div_Team_neo" {
+		t.Errorf("nickname = %q", body.Nickname)
+	}
+}

--- a/internal/http/handlers/discord_test.go
+++ b/internal/http/handlers/discord_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,8 +21,10 @@ import (
 )
 
 type fakeBot struct {
-	grantErr  error
-	kicked    bool
+	grantErr error
+	kicked   bool
+
+	mu        sync.Mutex
 	announced []string
 	nickname  string
 }
@@ -38,13 +41,35 @@ func (f *fakeBot) GetMember(_ context.Context, _ string) (*discord.Member, error
 }
 
 func (f *fakeBot) Announce(_ context.Context, content string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.announced = append(f.announced, content)
 	return nil
 }
 
 func (f *fakeBot) SetNickname(_ context.Context, _, nickname string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.nickname = nickname
 	return nil
+}
+
+func (f *fakeBot) announcedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.announced)
+}
+
+func (f *fakeBot) announcedAt(i int) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.announced[i]
+}
+
+func (f *fakeBot) nick() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.nickname
 }
 
 type fakeOAuth struct {
@@ -206,6 +231,7 @@ func TestHandlerDiscordConnectAndCallback(t *testing.T) {
 	cbCtx, cbRec := newJSONContext(t, http.MethodGet, "/api/discord/callback?code=abc&state="+state, nil)
 	cbCtx.Set("userID", user.ID)
 	h.DiscordCallback(cbCtx)
+	h.discord.Wait()
 	if cbRec.Code != http.StatusFound {
 		t.Fatalf("callback code = %d body=%s", cbRec.Code, cbRec.Body.String())
 	}
@@ -238,6 +264,7 @@ func TestHandlerDiscordSyncRole(t *testing.T) {
 	cbCtx, cbRec := newJSONContext(t, http.MethodGet, "/api/discord/callback?code=abc&state="+state.Query().Get("state"), nil)
 	cbCtx.Set("userID", user.ID)
 	h.DiscordCallback(cbCtx)
+	h.discord.Wait()
 	if loc := cbRec.Header().Get("Location"); !strings.Contains(loc, "discord=connected_not_joined") {
 		t.Fatalf("callback location = %q", loc)
 	}
@@ -265,6 +292,7 @@ func TestHandlerDiscordCallbackInvalidState(t *testing.T) {
 	ctx, rec := newJSONContext(t, http.MethodGet, "/api/discord/callback?code=abc&state=bogus", nil)
 	ctx.Set("userID", user.ID)
 	h.DiscordCallback(ctx)
+	h.discord.Wait()
 
 	if rec.Code != http.StatusFound {
 		t.Fatalf("code = %d", rec.Code)
@@ -289,6 +317,7 @@ func TestHandlerDiscordUnlink(t *testing.T) {
 	cbCtx, _ := newJSONContext(t, http.MethodGet, "/api/discord/callback?code=abc&state="+state.Query().Get("state"), nil)
 	cbCtx.Set("userID", user.ID)
 	h.DiscordCallback(cbCtx)
+	h.discord.Wait()
 
 	unlinkCtx, unlinkRec := newJSONContext(t, http.MethodDelete, "/api/discord/unlink", nil)
 	unlinkCtx.Set("userID", user.ID)
@@ -322,13 +351,14 @@ func TestHandlerSubmitFlagAnnounces(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("submit status %d: %s", rec.Code, rec.Body.String())
 	}
+	h.discord.Wait()
 
-	if len(bot.announced) != 1 {
-		t.Fatalf("expected 1 announcement, got %d", len(bot.announced))
+	if bot.announcedCount() != 1 {
+		t.Fatalf("expected 1 announcement, got %d", bot.announcedCount())
 	}
 
-	if !strings.Contains(bot.announced[0], "AnnounceChal") || !strings.Contains(bot.announced[0], "First Blood") {
-		t.Errorf("announce = %q", bot.announced[0])
+	if !strings.Contains(bot.announcedAt(0), "AnnounceChal") || !strings.Contains(bot.announcedAt(0), "First Blood") {
+		t.Errorf("announce = %q", bot.announcedAt(0))
 	}
 }
 
@@ -350,7 +380,8 @@ func TestHandlerUpdateMeSyncsNickname(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("update status %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(bot.nickname, "renamed") {
-		t.Fatalf("expected nickname synced to renamed, got %q", bot.nickname)
+	h.discord.Wait()
+	if !strings.Contains(bot.nick(), "renamed") {
+		t.Fatalf("expected nickname synced to renamed, got %q", bot.nick())
 	}
 }

--- a/internal/http/handlers/discord_test.go
+++ b/internal/http/handlers/discord_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,8 +20,10 @@ import (
 )
 
 type fakeBot struct {
-	grantErr error
-	kicked   bool
+	grantErr  error
+	kicked    bool
+	announced []string
+	nickname  string
 }
 
 func (f *fakeBot) JoinGuild(_ context.Context, _, _ string) error { return nil }
@@ -32,6 +35,16 @@ func (f *fakeBot) KickMember(_ context.Context, _ string) error {
 
 func (f *fakeBot) GetMember(_ context.Context, _ string) (*discord.Member, error) {
 	return &discord.Member{}, nil
+}
+
+func (f *fakeBot) Announce(_ context.Context, content string) error {
+	f.announced = append(f.announced, content)
+	return nil
+}
+
+func (f *fakeBot) SetNickname(_ context.Context, _, nickname string) error {
+	f.nickname = nickname
+	return nil
 }
 
 type fakeOAuth struct {
@@ -59,7 +72,7 @@ func discordEnabledHandler(env handlerEnv, bot discord.BotAPI, user *discord.Use
 		SuccessRedirect: "http://localhost:3000/profile",
 		InviteURL:       "https://discord.gg/invite",
 	}
-	discordSvc := service.NewDiscordService(cfg.Discord, repo.NewDiscordRepo(env.db), bot, fakeOAuth{user: user}, env.redis)
+	discordSvc := service.NewDiscordService(cfg.Discord, repo.NewDiscordRepo(env.db), env.userRepo, bot, fakeOAuth{user: user}, env.redis)
 	return New(cfg, env.authSvc, env.ctfSvc, env.appConfigSvc, env.userSvc, env.scoreSvc, env.divisionSvc, env.teamSvc, env.vmSvc, env.redis, discordSvc)
 }
 
@@ -291,5 +304,53 @@ func TestHandlerDiscordUnlink(t *testing.T) {
 
 	if _, err := repo.NewDiscordRepo(env.db).GetByUserID(context.Background(), user.ID); err == nil {
 		t.Error("connection should be deleted")
+	}
+}
+
+func TestHandlerSubmitFlagAnnounces(t *testing.T) {
+	env := setupHandlerTest(t)
+	user := createHandlerUser(t, env, "solveann@example.com", "solveann", "pass", models.UserRole)
+	ch := createHandlerChallenge(t, env, "AnnounceChal", 100, "FLAG{ANN}", true)
+	bot := &fakeBot{}
+	h := discordEnabledHandler(env, bot, &discord.User{ID: "1"})
+
+	ctx, rec := newJSONContext(t, http.MethodPost, "/api/challenges/x/submit", map[string]string{"flag": "FLAG{ANN}"})
+	ctx.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", ch.ID)}}
+	ctx.Set("userID", user.ID)
+
+	h.SubmitFlag(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("submit status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if len(bot.announced) != 1 {
+		t.Fatalf("expected 1 announcement, got %d", len(bot.announced))
+	}
+
+	if !strings.Contains(bot.announced[0], "AnnounceChal") || !strings.Contains(bot.announced[0], "First Blood") {
+		t.Errorf("announce = %q", bot.announced[0])
+	}
+}
+
+func TestHandlerUpdateMeSyncsNickname(t *testing.T) {
+	env := setupHandlerTest(t)
+	user := createHandlerUser(t, env, "nickupd@example.com", "nickupd", "pass", models.UserRole)
+	bot := &fakeBot{}
+	h := discordEnabledHandler(env, bot, &discord.User{ID: "1"})
+
+	conn := &models.DiscordConnection{UserID: user.ID, DiscordUserID: "1", RoleStatus: models.DiscordStatusVerified, ConnectedAt: time.Now().UTC()}
+	if err := repo.NewDiscordRepo(env.db).Create(context.Background(), conn); err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+
+	ctx, rec := newJSONContext(t, http.MethodPut, "/api/me", map[string]string{"username": "renamed"})
+	ctx.Set("userID", user.ID)
+
+	h.UpdateMe(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(bot.nickname, "renamed") {
+		t.Fatalf("expected nickname synced to renamed, got %q", bot.nickname)
 	}
 }

--- a/internal/http/handlers/handler.go
+++ b/internal/http/handlers/handler.go
@@ -489,6 +489,10 @@ func (h *Handler) UpdateMe(ctx *gin.Context) {
 
 	h.notifyScoreboardChanged(ctx.Request.Context(), "user_profile_update", user.DivisionID)
 
+	if h.discord != nil {
+		h.discord.SyncNickname(ctx.Request.Context(), userID)
+	}
+
 	ctx.JSON(http.StatusOK, newUserMeResponse(user, vmCount, vmLimit))
 }
 
@@ -597,6 +601,17 @@ func (h *Handler) SubmitFlag(ctx *gin.Context) {
 
 		if h.vms != nil {
 			_ = h.vms.DeleteVMByUserAndChallenge(ctx.Request.Context(), middleware.UserID(ctx), challengeID)
+		}
+
+		if h.discord != nil {
+			uid := middleware.UserID(ctx)
+			firstBlood, _ := h.ctf.WasFirstBlood(ctx.Request.Context(), uid, challengeID)
+			title := ""
+			if ch, cerr := h.ctf.GetChallengeByID(ctx.Request.Context(), challengeID); cerr == nil {
+				title = ch.Title
+			}
+
+			h.discord.AnnounceSolve(ctx.Request.Context(), uid, title, firstBlood)
 		}
 	}
 

--- a/internal/http/handlers/handler.go
+++ b/internal/http/handlers/handler.go
@@ -489,7 +489,7 @@ func (h *Handler) UpdateMe(ctx *gin.Context) {
 
 	h.notifyScoreboardChanged(ctx.Request.Context(), "user_profile_update", user.DivisionID)
 
-	if h.discord != nil {
+	if h.discord != nil && req.Username != nil {
 		h.discord.SyncNickname(ctx.Request.Context(), userID)
 	}
 
@@ -605,13 +605,10 @@ func (h *Handler) SubmitFlag(ctx *gin.Context) {
 
 		if h.discord != nil {
 			uid := middleware.UserID(ctx)
-			firstBlood, _ := h.ctf.WasFirstBlood(ctx.Request.Context(), uid, challengeID)
-			title := ""
-			if ch, cerr := h.ctf.GetChallengeByID(ctx.Request.Context(), challengeID); cerr == nil {
-				title = ch.Title
+			if ch, cerr := h.ctf.GetChallengeByID(ctx.Request.Context(), challengeID); cerr == nil && ch.Title != "" {
+				firstBlood, _ := h.ctf.WasFirstBlood(ctx.Request.Context(), uid, challengeID)
+				h.discord.AnnounceSolve(ctx.Request.Context(), uid, ch.Title, firstBlood)
 			}
-
-			h.discord.AnnounceSolve(ctx.Request.Context(), uid, title, firstBlood)
 		}
 	}
 

--- a/internal/repo/submission_repo.go
+++ b/internal/repo/submission_repo.go
@@ -2,6 +2,8 @@ package repo
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"smctf/internal/models"
 
@@ -72,6 +74,26 @@ func (r *SubmissionRepo) lockChallengeScope(ctx context.Context, db bun.IDB, cha
 	}
 
 	return nil
+}
+
+func (r *SubmissionRepo) WasFirstBlood(ctx context.Context, userID, challengeID int64) (bool, error) {
+	var firstBlood bool
+	err := r.db.NewSelect().
+		Model((*models.Submission)(nil)).
+		Column("is_first_blood").
+		Where("user_id = ?", userID).
+		Where("challenge_id = ?", challengeID).
+		Where("correct = true").
+		Limit(1).
+		Scan(ctx, &firstBlood)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, wrapError("submissionRepo.WasFirstBlood", err)
+	}
+
+	return firstBlood, nil
 }
 
 func (r *SubmissionRepo) correctSubmissionCount(

--- a/internal/repo/submission_repo_test.go
+++ b/internal/repo/submission_repo_test.go
@@ -454,3 +454,33 @@ func TestSubmissionRepoCreateCorrectIfNotSolvedByTeamIncorrect(t *testing.T) {
 		t.Fatalf("expected incorrect submission to be inserted")
 	}
 }
+
+func TestSubmissionRepoWasFirstBlood(t *testing.T) {
+	env := setupRepoTest(t)
+	user := createUserWithNewTeam(t, env, "fb1@example.com", "fb1", "pass", models.UserRole)
+	ch := createChallenge(t, env, "fbch", 100, "FLAG{FB}", true)
+
+	sub := &models.Submission{UserID: user.ID, ChallengeID: ch.ID, Correct: true, SubmittedAt: time.Now().UTC()}
+	if _, err := env.submissionRepo.CreateCorrectIfNotSolvedByTeam(context.Background(), sub); err != nil {
+		t.Fatalf("create correct: %v", err)
+	}
+
+	fb, err := env.submissionRepo.WasFirstBlood(context.Background(), user.ID, ch.ID)
+	if err != nil {
+		t.Fatalf("WasFirstBlood: %v", err)
+	}
+
+	if !fb {
+		t.Fatal("expected first blood true for the first solver")
+	}
+
+	other := createChallenge(t, env, "fbch2", 100, "FLAG{FB2}", true)
+	fb, err = env.submissionRepo.WasFirstBlood(context.Background(), user.ID, other.ID)
+	if err != nil {
+		t.Fatalf("WasFirstBlood no submission: %v", err)
+	}
+
+	if fb {
+		t.Fatal("expected false when there is no correct submission")
+	}
+}

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -44,6 +44,7 @@ func (s *AuthService) Register(ctx context.Context, email, username, password, r
 	validator := newFieldValidator()
 	validator.Required("email", email)
 	validator.Required("username", username)
+	validator.MaxLen("username", username, nameMaxLen)
 	validator.Required("password", password)
 	validator.Required("registration_key", registrationKey)
 	validator.Email("email", email)

--- a/internal/service/auth_service_test.go
+++ b/internal/service/auth_service_test.go
@@ -72,6 +72,29 @@ func TestAuthServiceRegisterPasswordTooLong(t *testing.T) {
 	}
 }
 
+func TestAuthServiceRegisterUsernameTooLong(t *testing.T) {
+	env := setupServiceTest(t)
+	admin := createUserWithNewTeam(t, env, "admin@example.com", models.AdminRole, "pass", models.AdminRole)
+	key := createRegistrationKey(t, env, "ABCDEFGHJKLMNPQ7", admin.ID)
+
+	_, err := env.authSvc.Register(context.Background(), "user@example.com", "ThisNameIsWayTooLong", "pass1", key.Code, "")
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+
+	found := false
+	for _, f := range ve.Fields {
+		if f.Field == "username" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected username length error, got %+v", ve.Fields)
+	}
+}
+
 func TestAuthServiceRegisterUserExists(t *testing.T) {
 	env := setupServiceTest(t)
 	admin := createUserWithNewTeam(t, env, "admin@example.com", models.AdminRole, "pass", models.AdminRole)

--- a/internal/service/ctf_service.go
+++ b/internal/service/ctf_service.go
@@ -408,6 +408,10 @@ func (s *CTFService) SubmitFlag(ctx context.Context, userID, challengeID int64, 
 	return correct, nil
 }
 
+func (s *CTFService) WasFirstBlood(ctx context.Context, userID, challengeID int64) (bool, error) {
+	return s.submissionRepo.WasFirstBlood(ctx, userID, challengeID)
+}
+
 func (s *CTFService) RequestChallengeFileUpload(ctx context.Context, id int64, filename string) (*models.Challenge, storage.PresignedPost, error) {
 	filename = normalizeTrim(filename)
 	validator := newFieldValidator()

--- a/internal/service/discord_service.go
+++ b/internal/service/discord_service.go
@@ -27,15 +27,17 @@ type DiscordOAuth interface {
 type DiscordService struct {
 	cfg   config.DiscordConfig
 	repo  *repo.DiscordRepo
+	users *repo.UserRepo
 	bot   discord.BotAPI
 	oauth DiscordOAuth
 	redis *redis.Client
 }
 
-func NewDiscordService(cfg config.DiscordConfig, discordRepo *repo.DiscordRepo, bot discord.BotAPI, oauth DiscordOAuth, redisClient *redis.Client) *DiscordService {
+func NewDiscordService(cfg config.DiscordConfig, discordRepo *repo.DiscordRepo, userRepo *repo.UserRepo, bot discord.BotAPI, oauth DiscordOAuth, redisClient *redis.Client) *DiscordService {
 	return &DiscordService{
 		cfg:   cfg,
 		repo:  discordRepo,
+		users: userRepo,
 		bot:   bot,
 		oauth: oauth,
 		redis: redisClient,
@@ -104,6 +106,8 @@ func (s *DiscordService) HandleCallback(ctx context.Context, userID int64, code,
 	if err := s.repo.Update(ctx, conn); err != nil {
 		return nil, err
 	}
+
+	s.SyncNickname(ctx, userID)
 
 	return conn, nil
 }
@@ -267,6 +271,54 @@ func (s *DiscordService) applyGrantError(conn *models.DiscordConnection, err err
 		conn.RoleStatus = models.DiscordStatusNotInGuild
 	default:
 		conn.RoleStatus = models.DiscordStatusRoleFailed
+	}
+}
+
+func (s *DiscordService) AnnounceSolve(ctx context.Context, userID int64, challengeTitle string, firstBlood bool) {
+	if err := s.ensureEnabled(); err != nil {
+		return
+	}
+
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		slog.Warn("discord announce: user lookup failed", slog.Int64("user_id", userID), slog.Any("error", err))
+		return
+	}
+
+	team := fmt.Sprintf("%s_%s", user.DivisionName, user.TeamName)
+	var content string
+	if firstBlood {
+		content = fmt.Sprintf("\U0001FA78 **First Blood!** **%s** — %s solved **%s**!", team, user.Username, challengeTitle)
+	} else {
+		content = fmt.Sprintf("**%s** — %s solved **%s**", team, user.Username, challengeTitle)
+	}
+
+	if err := s.bot.Announce(ctx, content); err != nil {
+		slog.Warn("discord announce failed", slog.Int64("user_id", userID), slog.Any("error", err))
+	}
+}
+
+func (s *DiscordService) SyncNickname(ctx context.Context, userID int64) {
+	if err := s.ensureEnabled(); err != nil {
+		return
+	}
+
+	conn, err := s.repo.GetByUserID(ctx, userID)
+	if err != nil {
+		return
+	}
+
+	user, err := s.users.GetByID(ctx, userID)
+	if err != nil {
+		slog.Warn("discord nickname: user lookup failed", slog.Int64("user_id", userID), slog.Any("error", err))
+		return
+	}
+
+	nickname := fmt.Sprintf("%s_%s_%s", user.DivisionName, user.TeamName, user.Username)
+	if err := s.bot.SetNickname(ctx, conn.DiscordUserID, nickname); err != nil {
+		if !errors.Is(err, discord.ErrNotInGuild) {
+			slog.Warn("discord nickname sync failed", slog.Int64("user_id", userID), slog.Any("error", err))
+		}
 	}
 }
 

--- a/internal/service/discord_service.go
+++ b/internal/service/discord_service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"smctf/internal/config"
@@ -31,6 +32,11 @@ type DiscordService struct {
 	bot   discord.BotAPI
 	oauth DiscordOAuth
 	redis *redis.Client
+	wg    sync.WaitGroup
+}
+
+func (s *DiscordService) Wait() {
+	s.wg.Wait()
 }
 
 func NewDiscordService(cfg config.DiscordConfig, discordRepo *repo.DiscordRepo, userRepo *repo.UserRepo, bot discord.BotAPI, oauth DiscordOAuth, redisClient *redis.Client) *DiscordService {
@@ -274,11 +280,19 @@ func (s *DiscordService) applyGrantError(conn *models.DiscordConnection, err err
 	}
 }
 
-func (s *DiscordService) AnnounceSolve(ctx context.Context, userID int64, challengeTitle string, firstBlood bool) {
+func (s *DiscordService) AnnounceSolve(_ context.Context, userID int64, challengeTitle string, firstBlood bool) {
 	if err := s.ensureEnabled(); err != nil {
 		return
 	}
 
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.announceSolve(context.Background(), userID, challengeTitle, firstBlood)
+	}()
+}
+
+func (s *DiscordService) announceSolve(ctx context.Context, userID int64, challengeTitle string, firstBlood bool) {
 	user, err := s.users.GetByID(ctx, userID)
 	if err != nil {
 		slog.Warn("discord announce: user lookup failed", slog.Int64("user_id", userID), slog.Any("error", err))
@@ -298,13 +312,24 @@ func (s *DiscordService) AnnounceSolve(ctx context.Context, userID int64, challe
 	}
 }
 
-func (s *DiscordService) SyncNickname(ctx context.Context, userID int64) {
+func (s *DiscordService) SyncNickname(_ context.Context, userID int64) {
 	if err := s.ensureEnabled(); err != nil {
 		return
 	}
 
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.syncNickname(context.Background(), userID)
+	}()
+}
+
+func (s *DiscordService) syncNickname(ctx context.Context, userID int64) {
 	conn, err := s.repo.GetByUserID(ctx, userID)
 	if err != nil {
+		if !errors.Is(err, repo.ErrNotFound) {
+			slog.Warn("discord nickname: connection lookup failed", slog.Int64("user_id", userID), slog.Any("error", err))
+		}
 		return
 	}
 

--- a/internal/service/discord_service_test.go
+++ b/internal/service/discord_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,12 +14,14 @@ import (
 )
 
 type fakeBot struct {
-	joinErr  error
-	grantErr error
-	kickErr  error
-	joined   bool
-	granted  bool
-	kicked   bool
+	joinErr   error
+	grantErr  error
+	kickErr   error
+	joined    bool
+	granted   bool
+	kicked    bool
+	announced []string
+	nickname  string
 }
 
 func (f *fakeBot) JoinGuild(_ context.Context, _, _ string) error {
@@ -38,6 +41,16 @@ func (f *fakeBot) KickMember(_ context.Context, _ string) error {
 
 func (f *fakeBot) GetMember(_ context.Context, _ string) (*discord.Member, error) {
 	return &discord.Member{}, nil
+}
+
+func (f *fakeBot) Announce(_ context.Context, content string) error {
+	f.announced = append(f.announced, content)
+	return nil
+}
+
+func (f *fakeBot) SetNickname(_ context.Context, _, nickname string) error {
+	f.nickname = nickname
+	return nil
 }
 
 type fakeOAuth struct {
@@ -68,7 +81,7 @@ func discordTestConfig() config.DiscordConfig {
 
 func newDiscordServiceForTest(env serviceEnv, bot discord.BotAPI, user *discord.User) (*DiscordService, *repo.DiscordRepo) {
 	discordRepo := repo.NewDiscordRepo(env.db)
-	svc := NewDiscordService(discordTestConfig(), discordRepo, bot, fakeOAuth{user: user}, env.redis)
+	svc := NewDiscordService(discordTestConfig(), discordRepo, env.userRepo, bot, fakeOAuth{user: user}, env.redis)
 	return svc, discordRepo
 }
 
@@ -225,7 +238,7 @@ func TestDiscordGetConnectionNilWhenAbsent(t *testing.T) {
 func TestDiscordDisabledReturnsError(t *testing.T) {
 	env := setupServiceTest(t)
 	discordRepo := repo.NewDiscordRepo(env.db)
-	svc := NewDiscordService(config.DiscordConfig{Enabled: false}, discordRepo, &fakeBot{}, fakeOAuth{user: &discord.User{ID: "1"}}, env.redis)
+	svc := NewDiscordService(config.DiscordConfig{Enabled: false}, discordRepo, env.userRepo, &fakeBot{}, fakeOAuth{user: &discord.User{ID: "1"}}, env.redis)
 
 	if _, err := svc.BeginConnect(context.Background(), 1); !errors.Is(err, ErrDiscordDisabled) {
 		t.Fatalf("got %v, want ErrDiscordDisabled", err)
@@ -239,4 +252,68 @@ func seedState(t *testing.T, env serviceEnv, userID int64) string {
 		t.Fatalf("seed state: %v", err)
 	}
 	return state
+}
+
+func TestDiscordAnnounceSolve(t *testing.T) {
+	env := setupServiceTest(t)
+	user := createUserWithNewTeam(t, env, "ann@example.com", "annuser", "pass", models.UserRole)
+	bot := &fakeBot{}
+	svc, _ := newDiscordServiceForTest(env, bot, &discord.User{ID: "1"})
+
+	svc.AnnounceSolve(context.Background(), user.ID, "Web-101", true)
+	svc.AnnounceSolve(context.Background(), user.ID, "Web-102", false)
+
+	if len(bot.announced) != 2 {
+		t.Fatalf("expected 2 announcements, got %d", len(bot.announced))
+	}
+
+	if !strings.Contains(bot.announced[0], "First Blood") || !strings.Contains(bot.announced[0], "Web-101") || !strings.Contains(bot.announced[0], "annuser") {
+		t.Errorf("first blood msg = %q", bot.announced[0])
+	}
+
+	if strings.Contains(bot.announced[1], "First Blood") || !strings.Contains(bot.announced[1], "solved") {
+		t.Errorf("normal msg = %q", bot.announced[1])
+	}
+}
+
+func TestDiscordSyncNickname(t *testing.T) {
+	env := setupServiceTest(t)
+	user := createUserWithNewTeam(t, env, "nick@example.com", "nickuser", "pass", models.UserRole)
+	bot := &fakeBot{}
+	svc, discordRepo := newDiscordServiceForTest(env, bot, &discord.User{ID: "555"})
+
+	svc.SyncNickname(context.Background(), user.ID)
+	if bot.nickname != "" {
+		t.Fatalf("expected skip without connection, got %q", bot.nickname)
+	}
+
+	conn := &models.DiscordConnection{UserID: user.ID, DiscordUserID: "555", RoleStatus: models.DiscordStatusVerified, ConnectedAt: time.Now().UTC()}
+	if err := discordRepo.Create(context.Background(), conn); err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+
+	svc.SyncNickname(context.Background(), user.ID)
+	if !strings.Contains(bot.nickname, "nickuser") {
+		t.Fatalf("nickname = %q (expected division_team_nickuser)", bot.nickname)
+	}
+}
+
+func TestCTFServiceWasFirstBlood(t *testing.T) {
+	env := setupServiceTest(t)
+	user := createUserWithNewTeam(t, env, "cfb@example.com", "cfb", "pass", models.UserRole)
+	ch := createChallenge(t, env, "cfbch", 100, "FLAG{CFB}", true)
+
+	correct, err := env.ctfSvc.SubmitFlag(context.Background(), user.ID, ch.ID, "FLAG{CFB}")
+	if err != nil || !correct {
+		t.Fatalf("submit: correct=%v err=%v", correct, err)
+	}
+
+	fb, err := env.ctfSvc.WasFirstBlood(context.Background(), user.ID, ch.ID)
+	if err != nil {
+		t.Fatalf("WasFirstBlood: %v", err)
+	}
+
+	if !fb {
+		t.Fatal("expected first blood for first solver")
+	}
 }

--- a/internal/service/discord_service_test.go
+++ b/internal/service/discord_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,12 +15,14 @@ import (
 )
 
 type fakeBot struct {
-	joinErr   error
-	grantErr  error
-	kickErr   error
-	joined    bool
-	granted   bool
-	kicked    bool
+	joinErr  error
+	grantErr error
+	kickErr  error
+	joined   bool
+	granted  bool
+	kicked   bool
+
+	mu        sync.Mutex
 	announced []string
 	nickname  string
 }
@@ -44,13 +47,35 @@ func (f *fakeBot) GetMember(_ context.Context, _ string) (*discord.Member, error
 }
 
 func (f *fakeBot) Announce(_ context.Context, content string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.announced = append(f.announced, content)
 	return nil
 }
 
 func (f *fakeBot) SetNickname(_ context.Context, _, nickname string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.nickname = nickname
 	return nil
+}
+
+func (f *fakeBot) announcedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.announced)
+}
+
+func (f *fakeBot) announcedAt(i int) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.announced[i]
+}
+
+func (f *fakeBot) nick() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.nickname
 }
 
 type fakeOAuth struct {
@@ -118,6 +143,7 @@ func TestDiscordHandleCallbackVerified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleCallback: %v", err)
 	}
+	svc.Wait()
 
 	if conn.RoleStatus != models.DiscordStatusVerified {
 		t.Errorf("status = %q", conn.RoleStatus)
@@ -149,6 +175,7 @@ func TestDiscordHandleCallbackNotInGuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleCallback: %v", err)
 	}
+	svc.Wait()
 
 	if conn.RoleStatus != models.DiscordStatusNotInGuild {
 		t.Errorf("status = %q", conn.RoleStatus)
@@ -182,6 +209,7 @@ func TestDiscordHandleCallbackAlreadyLinked(t *testing.T) {
 	if _, err := svc.HandleCallback(context.Background(), owner.ID, "code", state); err != nil {
 		t.Fatalf("owner link: %v", err)
 	}
+	svc.Wait()
 
 	state2 := seedState(t, env, other.ID)
 	_, err := svc.HandleCallback(context.Background(), other.ID, "code", state2)
@@ -205,6 +233,7 @@ func TestDiscordUnlinkRemovesConnection(t *testing.T) {
 	if _, err := svc.HandleCallback(context.Background(), user.ID, "code", state); err != nil {
 		t.Fatalf("link: %v", err)
 	}
+	svc.Wait()
 
 	if err := svc.Unlink(context.Background(), user.ID); err != nil {
 		t.Fatalf("Unlink: %v", err)
@@ -261,18 +290,20 @@ func TestDiscordAnnounceSolve(t *testing.T) {
 	svc, _ := newDiscordServiceForTest(env, bot, &discord.User{ID: "1"})
 
 	svc.AnnounceSolve(context.Background(), user.ID, "Web-101", true)
+	svc.Wait()
 	svc.AnnounceSolve(context.Background(), user.ID, "Web-102", false)
+	svc.Wait()
 
-	if len(bot.announced) != 2 {
-		t.Fatalf("expected 2 announcements, got %d", len(bot.announced))
+	if bot.announcedCount() != 2 {
+		t.Fatalf("expected 2 announcements, got %d", bot.announcedCount())
 	}
 
-	if !strings.Contains(bot.announced[0], "First Blood") || !strings.Contains(bot.announced[0], "Web-101") || !strings.Contains(bot.announced[0], "annuser") {
-		t.Errorf("first blood msg = %q", bot.announced[0])
+	if !strings.Contains(bot.announcedAt(0), "First Blood") || !strings.Contains(bot.announcedAt(0), "Web-101") || !strings.Contains(bot.announcedAt(0), "annuser") {
+		t.Errorf("first blood msg = %q", bot.announcedAt(0))
 	}
 
-	if strings.Contains(bot.announced[1], "First Blood") || !strings.Contains(bot.announced[1], "solved") {
-		t.Errorf("normal msg = %q", bot.announced[1])
+	if strings.Contains(bot.announcedAt(1), "First Blood") || !strings.Contains(bot.announcedAt(1), "solved") {
+		t.Errorf("normal msg = %q", bot.announcedAt(1))
 	}
 }
 
@@ -283,8 +314,9 @@ func TestDiscordSyncNickname(t *testing.T) {
 	svc, discordRepo := newDiscordServiceForTest(env, bot, &discord.User{ID: "555"})
 
 	svc.SyncNickname(context.Background(), user.ID)
-	if bot.nickname != "" {
-		t.Fatalf("expected skip without connection, got %q", bot.nickname)
+	svc.Wait()
+	if bot.nick() != "" {
+		t.Fatalf("expected skip without connection, got %q", bot.nick())
 	}
 
 	conn := &models.DiscordConnection{UserID: user.ID, DiscordUserID: "555", RoleStatus: models.DiscordStatusVerified, ConnectedAt: time.Now().UTC()}
@@ -293,8 +325,9 @@ func TestDiscordSyncNickname(t *testing.T) {
 	}
 
 	svc.SyncNickname(context.Background(), user.ID)
-	if !strings.Contains(bot.nickname, "nickuser") {
-		t.Fatalf("nickname = %q (expected division_team_nickuser)", bot.nickname)
+	svc.Wait()
+	if !strings.Contains(bot.nick(), "nickuser") {
+		t.Fatalf("nickname = %q (expected division_team_nickuser)", bot.nick())
 	}
 }
 

--- a/internal/service/division_service.go
+++ b/internal/service/division_service.go
@@ -24,6 +24,7 @@ func (s *DivisionService) CreateDivision(ctx context.Context, name string) (*mod
 	name = strings.TrimSpace(name)
 	validator := newFieldValidator()
 	validator.Required("name", name)
+	validator.MaxLen("name", name, nameMaxLen)
 	if err := validator.Error(); err != nil {
 		return nil, err
 	}
@@ -64,6 +65,7 @@ func (s *DivisionService) GetDivision(ctx context.Context, id int64) (*models.Di
 		if errors.Is(err, repo.ErrNotFound) {
 			return nil, ErrNotFound
 		}
+
 		return nil, fmt.Errorf("division.GetDivision: %w", err)
 	}
 

--- a/internal/service/division_service_test.go
+++ b/internal/service/division_service_test.go
@@ -13,6 +13,10 @@ func TestDivisionServiceCreateListGet(t *testing.T) {
 		t.Fatalf("expected validation error")
 	}
 
+	if _, err := env.divisionSvc.CreateDivision(context.Background(), "ThisNameIsWayTooLong"); err == nil {
+		t.Fatalf("expected max-length validation error")
+	}
+
 	division, err := env.divisionSvc.CreateDivision(context.Background(), "Alpha")
 	if err != nil {
 		t.Fatalf("create division: %v", err)

--- a/internal/service/team_service.go
+++ b/internal/service/team_service.go
@@ -25,6 +25,7 @@ func (s *TeamService) CreateTeam(ctx context.Context, name string, divisionID in
 	name = strings.TrimSpace(name)
 	validator := newFieldValidator()
 	validator.Required("name", name)
+	validator.MaxLen("name", name, nameMaxLen)
 	validator.PositiveID("division_id", divisionID)
 	if err := validator.Error(); err != nil {
 		return nil, err

--- a/internal/service/team_service_test.go
+++ b/internal/service/team_service_test.go
@@ -15,6 +15,10 @@ func TestTeamServiceCreateAndList(t *testing.T) {
 		t.Fatalf("expected validation error")
 	}
 
+	if _, err := env.teamSvc.CreateTeam(context.Background(), "ThisNameIsWayTooLong", env.defaultDivisionID); err == nil {
+		t.Fatalf("expected max-length validation error")
+	}
+
 	_, err := env.teamSvc.CreateTeam(context.Background(), "Alpha", env.defaultDivisionID+999)
 	var ve *ValidationError
 	if !errors.As(err, &ve) {

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"smctf/internal/db"
 	"smctf/internal/models"
@@ -86,6 +87,10 @@ func (s *UserService) UpdateProfile(ctx context.Context, userID int64, username 
 		normalizedUsername := normalizeTrim(*username)
 		if normalizedUsername == "" {
 			return nil, NewValidationError(FieldError{Field: "username", Reason: "required"})
+		}
+
+		if utf8.RuneCountInString(normalizedUsername) > nameMaxLen {
+			return nil, NewValidationError(FieldError{Field: "username", Reason: fmt.Sprintf("max length is %d characters", nameMaxLen)})
 		}
 
 		exists, err := s.userRepo.ExistsByUsername(ctx, normalizedUsername, &userID)

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -175,19 +175,24 @@ func TestUserServiceUpdateProfileTrimAndRequired(t *testing.T) {
 	env := setupServiceTest(t)
 	user := createUserWithNewTeam(t, env, "trim@example.com", "trim-user", "pass", models.UserRole)
 
-	newName := "  trimmed-name  "
+	newName := "  trimmed  "
 	updated, err := env.userSvc.UpdateProfile(context.Background(), user.ID, &newName)
 	if err != nil {
 		t.Fatalf("expected trim update success, got %v", err)
 	}
 
-	if updated.Username != "trimmed-name" {
+	if updated.Username != "trimmed" {
 		t.Fatalf("expected trimmed username, got %q", updated.Username)
 	}
 
 	blank := strings.Repeat(" ", 5)
 	if _, err := env.userSvc.UpdateProfile(context.Background(), user.ID, &blank); err == nil {
 		t.Fatalf("expected validation error for blank username")
+	}
+
+	tooLong := "ThisNameIsWayTooLong"
+	if _, err := env.userSvc.UpdateProfile(context.Background(), user.ID, &tooLong); err == nil {
+		t.Fatalf("expected validation error for over-length username")
 	}
 }
 

--- a/internal/service/validation.go
+++ b/internal/service/validation.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 	"net/mail"
 	"strings"
+	"unicode/utf8"
 )
 
 const bcryptInputMaxBytes = 72
+
+// nameMaxLen bounds username, team name, and division name to 10 characters
+// each. Combined as "division_team_username" (10+10+10 + two underscores) this
+// fits Discord's 32-character nickname limit exactly.
+const nameMaxLen = 10
 
 type fieldValidator struct {
 	fields []FieldError
@@ -41,6 +47,12 @@ func (v *fieldValidator) Email(field, value string) {
 
 	if _, err := mail.ParseAddress(value); err != nil {
 		v.fields = append(v.fields, FieldError{Field: field, Reason: "invalid format"})
+	}
+}
+
+func (v *fieldValidator) MaxLen(field, value string, max int) {
+	if utf8.RuneCountInString(value) > max {
+		v.fields = append(v.fields, FieldError{Field: field, Reason: fmt.Sprintf("max length is %d characters", max)})
 	}
 }
 

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -14,6 +14,7 @@ func TestFieldValidator(t *testing.T) {
 	v.NonNegative("points", -1)
 	v.PositiveID("challenge_id", 0)
 	v.MaxBytes("password", strings.Repeat("a", 73), bcryptInputMaxBytes)
+	v.MaxLen("username", strings.Repeat("a", nameMaxLen+1), nameMaxLen)
 
 	err := v.Error()
 
@@ -22,8 +23,23 @@ func TestFieldValidator(t *testing.T) {
 		t.Fatalf("expected validation error, got %v", err)
 	}
 
-	if len(ve.Fields) != 6 {
-		t.Fatalf("expected 6 fields, got %d", len(ve.Fields))
+	if len(ve.Fields) != 7 {
+		t.Fatalf("expected 7 fields, got %d", len(ve.Fields))
+	}
+}
+
+func TestMaxLenCountsRunesNotBytes(t *testing.T) {
+	// Exactly nameMaxLen multi-byte (Korean) characters must pass; one more fails.
+	ok := newFieldValidator()
+	ok.MaxLen("username", strings.Repeat("가", nameMaxLen), nameMaxLen)
+	if err := ok.Error(); err != nil {
+		t.Fatalf("expected %d Korean chars to pass, got %v", nameMaxLen, err)
+	}
+
+	over := newFieldValidator()
+	over.MaxLen("username", strings.Repeat("가", nameMaxLen+1), nameMaxLen)
+	if err := over.Error(); err == nil {
+		t.Fatalf("expected %d Korean chars to fail", nameMaxLen+1)
 	}
 }
 

--- a/invite-bot/.env.example
+++ b/invite-bot/.env.example
@@ -14,3 +14,6 @@ DISCORD_VERIFIED_ROLE_ID=
 
 # Optional
 DISCORD_AUDIT_REASON=External site verification
+
+# Channel where solve announcements are posted (empty = announcements disabled)
+DISCORD_ANNOUNCE_CHANNEL_ID=

--- a/invite-bot/src/config.ts
+++ b/invite-bot/src/config.ts
@@ -4,6 +4,7 @@ export interface BotConfig {
     botToken: string
     guildId: string
     verifiedRoleId: string
+    announceChannelId: string
     auditReason: string
 }
 
@@ -45,6 +46,7 @@ export function loadConfig(): BotConfig {
         botToken: required('DISCORD_BOT_TOKEN'),
         guildId: required('DISCORD_GUILD_ID'),
         verifiedRoleId: required('DISCORD_VERIFIED_ROLE_ID'),
+        announceChannelId: optional('DISCORD_ANNOUNCE_CHANNEL_ID', ''),
         auditReason: optional('DISCORD_AUDIT_REASON', 'External site verification'),
     }
 }

--- a/invite-bot/src/discord/client.ts
+++ b/invite-bot/src/discord/client.ts
@@ -91,6 +91,33 @@ export class DiscordBot {
         }
     }
 
+    async announce(content: string): Promise<void> {
+        if (!this.cfg.announceChannelId) {
+            return
+        }
+        try {
+            const channel = await this.client.channels.fetch(this.cfg.announceChannelId)
+            if (!channel || !channel.isTextBased() || !('send' in channel)) {
+                throw new BotError(400, 'INVALID', 'announce channel is not text-based')
+            }
+            await channel.send({ content, allowedMentions: { parse: [] } })
+        } catch (err) {
+            if (err instanceof BotError) {
+                throw err
+            }
+            throw mapDiscordError(err)
+        }
+    }
+
+    async setNickname(userId: string, nickname: string): Promise<void> {
+        const member = await this.fetchMember(userId)
+        try {
+            await member.setNickname(nickname.slice(0, 32), this.cfg.auditReason)
+        } catch (err) {
+            throw mapDiscordError(err)
+        }
+    }
+
     private async fetchMember(userId: string): Promise<GuildMember> {
         const guild = this.requireGuild()
         try {

--- a/invite-bot/src/http/server.ts
+++ b/invite-bot/src/http/server.ts
@@ -107,6 +107,28 @@ export function buildServer(cfg: BotConfig, bot: DiscordBot): Express {
         }),
     )
 
+    internal.post(
+        '/announce',
+        asyncRoute(async (req, res) => {
+            const content = (req.body?.content as string | undefined) ?? ''
+            if (content.trim() === '') {
+                res.status(400).json({ error: 'content required', code: 'INVALID' })
+                return
+            }
+            await bot.announce(content)
+            res.status(204).end()
+        }),
+    )
+
+    internal.patch(
+        '/guild/members/:userId/nickname',
+        asyncRoute(async (req, res) => {
+            const nickname = (req.body?.nickname as string | undefined) ?? ''
+            await bot.setNickname(pathUserId(req), nickname)
+            res.status(204).end()
+        }),
+    )
+
     app.use('/internal', internal)
 
     return app


### PR DESCRIPTION
This PR adds Discord notifications for challenge solves. Messages are sent to the channel specified by `DISCORD_ANNOUNCE_CHANNEL_ID`, with **First Blood** solves receiving special emphasis.

Example:

```text
🩸 First Blood! 청소년부_B — kim6wol0 solved member_directory test!
청소년부_A — KimJunYoung solved member_directory test
```

In addition, the Invite Bot now automatically sets a member's guild nickname to the format:

```
<Division>_<TeamName>_<Username>
```

If a user later updates their profile information, the bot automatically synchronizes the guild nickname to reflect the updated values.

Since Discord limits nicknames to **32 characters**, the division name, team name, and username are each now limited to **10 characters** to ensure the generated nickname remains within the limit.

For more details, please refer to the changes included in this PR.

> [!Note]
>
> In a future update, different Discord roles and solve announcement channels will be configurable on a per-division basis.
